### PR TITLE
fix(menu): repair all /menu flows

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -59,6 +59,17 @@ def get_accounts(account_type: Optional[str] = None, use_cache: bool = True) -> 
         params["type"] = account_type
 
     accounts = safe_get("/api/v1/accounts", params)
+    if account_type and not accounts:
+        logging.warning(
+            "No accounts returned with API filter type=%s; falling back to local filter",
+            account_type,
+        )
+        all_accounts = safe_get("/api/v1/accounts", {"limit": 1000})
+        accounts = [
+            account
+            for account in all_accounts
+            if account.get("attributes", {}).get("type") == account_type
+        ]
     if use_cache and accounts:
         cache.set(cache_key, accounts)
     return accounts

--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -25,12 +25,15 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
     await query.answer()
     data = query.data
 
-    if data == "menu_assets":
+    if data == "menu_expense":
+        await start_expense_button(update, context)
+    elif data == "menu_assets":
         await list_assets(query, context)
     elif data == "menu_cuenta":
         await query.message.reply_text(
-            "Escribí el nombre de la cuenta o elegí una de 💼 Ver cuentas."
+            "Elegí una cuenta para ver saldo y movimientos:"
         )
+        await list_assets(query, context)
     elif data == "menu_commands":
         await list_commands(query, context)
 
@@ -38,5 +41,5 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
 menu_handlers = [
     CommandHandler("start", start_menu),
     CommandHandler("menu", start_menu),
-    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands)$")
+    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_expense|menu_assets|menu_cuenta|menu_commands)$")
 ]


### PR DESCRIPTION
## Summary
- fix the /menu callback routing for expense flow
- make asset listing resilient when Firefly returns empty filtered results
- make "Ver cuenta + movimientos" lead to the real account selection flow

## Changes
| File | Change |
|------|--------|
| `bot/handlers/menu.py` | fixed menu callback routing and account-detail flow |
| `bot/client.py` | added fallback for filtered account retrieval |

## Test Plan
- [x] Syntax validation with `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile ...`
- [x] Reviewed `/menu` callbacks manually in code

## Notes
- `gh auth status` reports the configured GitHub token is invalid, so automated issue/PR metadata may require re-authentication.