### PR TITLE
fix(menu): route expense callback through conversation

### DIFF
--- a/.github/workflows/ci-compile.yml
+++ b/.github/workflows/ci-compile.yml
@@ -1,0 +1,24 @@
+name: Python Compile Check
+
+on:
+  pull_request:
+
+concurrency:
+  group: ci-compile-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run compile check
+        run: PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile run.py bot/*.py bot/handlers/*.py

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,7 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_ENV
 
       - name: Build and Push Docker image (multiarch)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 
 # SDD / Agent skills
 .atl/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ venv/
 # SDD / Agent skills
 .atl/
 .DS_Store
+
+# Local Codex plugins
+plugins/

--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -1,7 +1,6 @@
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
 from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
 
-from bot.handlers.expense import start_expense_button
 from bot.handlers.common import list_commands
 from bot.handlers.assets import list_assets
 from bot.middleware import require_auth
@@ -25,9 +24,7 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
     await query.answer()
     data = query.data
 
-    if data == "menu_expense":
-        await start_expense_button(update, context)
-    elif data == "menu_assets":
+    if data == "menu_assets":
         await list_assets(query, context)
     elif data == "menu_cuenta":
         await query.message.reply_text(
@@ -41,5 +38,8 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
 menu_handlers = [
     CommandHandler("start", start_menu),
     CommandHandler("menu", start_menu),
-    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_expense|menu_assets|menu_cuenta|menu_commands)$")
+    # `menu_expense` is intentionally handled by the expense ConversationHandler.
+    # If this generic menu handler consumes it first, the expense flow displays
+    # the account buttons but never enters SELECT_ORIGIN.
+    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands)$")
 ]


### PR DESCRIPTION
## Summary
- Routes the expense menu callback through the expense ConversationHandler.
- Prevents origin account selections from becoming static/no-op after opening the expense flow from /menu.
- Adds a Python compile CI workflow, ignores .DS_Store, and updates docker/build-push-action to v7.

## Test Plan
- Syntax checked with py_compile using PYTHONPYCACHEPREFIX=/tmp/pycache.
- CI compile workflow added for pull requests.
- Manual runtime test pending in container.