### PR TITLE
feat(expense): improve flow test coverage

### DIFF
--- a/.github/workflows/ci-compile.yml
+++ b/.github/workflows/ci-compile.yml
@@ -20,5 +20,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
       - name: Run compile check
-        run: PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile run.py bot/*.py bot/handlers/*.py
+        run: PYTHONPYCACHEPREFIX=/tmp/pycache python -m py_compile run.py bot/*.py bot/handlers/*.py tests/*.py
+
+      - name: Run tests
+        run: pytest

--- a/bot/handlers/expense.py
+++ b/bot/handlers/expense.py
@@ -268,8 +268,7 @@ async def select_origin(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     await query.message.reply_text(
         "Ahora escribí el monto y la descripción.\n"
-        "Ejemplo: `13.99 hamburguesa`\n\n"
-        "También podés escribir solo el monto y agregar la descripción después.",
+        "Ejemplo: `13.99 hamburguesa`",
         reply_markup=_get_keyboard_with_cancel([]),
     )
     return ENTER_AMOUNT_DESC
@@ -293,15 +292,13 @@ async def enter_amount_description(update: Update, context: ContextTypes.DEFAULT
 
     if not description:
         await update.message.reply_text(
-            "Falta la descripción. Escribila ahora:"
+            "Falta la descripción. Escribí el monto y la descripción juntos.\n"
+            "Ejemplo: `13.99 hamburguesa`"
         )
-        context.user_data["amount"] = amount
-        context.user_data["awaiting_description"] = True
         return ENTER_AMOUNT_DESC
 
     context.user_data["amount"] = amount
     context.user_data["description"] = description
-    context.user_data.pop("awaiting_description", None)
 
     # Show destination selection
     accounts = get_accounts(account_type="expense")
@@ -445,11 +442,24 @@ async def _show_tag_input(message_source, context: ContextTypes.DEFAULT_TYPE):
     """Prompt for tags input."""
     await message_source.reply_text(
         "Escribí tags separados por coma (opcional).\n"
-        "Ejemplo: `comida, delivery, almuerzo`\n"
-        "O escribí `skip` para continuar sin tags.",
-        reply_markup=_get_keyboard_with_cancel([]),
+        "Ejemplo: `comida, delivery, almuerzo`\n\n"
+        "O tocá el botón para continuar sin tags.",
+        reply_markup=_get_keyboard_with_cancel(
+            [[InlineKeyboardButton("⏭️ Sin tags", callback_data="tags::none")]]
+        ),
     )
     return ENTER_TAGS
+
+
+async def skip_tags(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Skip tags from the inline button."""
+    query = update.callback_query
+    await query.answer()
+
+    context.user_data["tags"] = []
+    logger.info("No tags entered")
+
+    return await _show_confirmation(query.message, context)
 
 
 async def enter_tags(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -774,6 +784,7 @@ expense_conv = ConversationHandler(
             CallbackQueryHandler(select_budget, pattern="^budget::"),
         ],
         ENTER_TAGS: [
+            CallbackQueryHandler(skip_tags, pattern="^tags::none$"),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_tags),
         ],
         CONFIRM_EXPENSE: [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pytz
 python-telegram-bot==20.8
 requests
 python-dotenv
+pytest
+pytest-asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,133 @@
+import pytest
+
+
+class FakeUser:
+    def __init__(self, user_id=123):
+        self.id = user_id
+
+
+class FakeMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append({"text": text, **kwargs})
+
+
+class FakeCallbackQuery:
+    def __init__(self, data, message=None):
+        self.data = data
+        self.message = message or FakeMessage()
+        self.answers = []
+
+    async def answer(self, text=None, **kwargs):
+        self.answers.append({"text": text, **kwargs})
+
+
+class FakeUpdate:
+    def __init__(self, message=None, callback_query=None, user_id=123):
+        self.message = message
+        self.callback_query = callback_query
+        self.effective_user = FakeUser(user_id)
+
+
+class FakeContext:
+    def __init__(self, args=None, user_data=None):
+        self.args = args or []
+        self.user_data = user_data if user_data is not None else {}
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_error=None, json_error=None):
+        self.payload = payload or {}
+        self.status_error = status_error
+        self.json_error = json_error
+
+    def raise_for_status(self):
+        if self.status_error:
+            raise self.status_error
+
+    def json(self):
+        if self.json_error:
+            raise self.json_error
+        return self.payload
+
+
+@pytest.fixture
+def asset_accounts():
+    return [
+        {
+            "id": "asset-1",
+            "attributes": {
+                "name": "tarjeta",
+                "type": "asset",
+                "current_balance": "100.00",
+            },
+        },
+        {
+            "id": "asset-2",
+            "attributes": {
+                "name": "efectivo",
+                "type": "asset",
+                "current_balance": "50.00",
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def expense_accounts():
+    return [
+        {"id": "expense-1", "attributes": {"name": "pingo doce", "type": "expense"}},
+        {"id": "expense-2", "attributes": {"name": "uber", "type": "expense"}},
+    ]
+
+
+@pytest.fixture
+def all_accounts(asset_accounts, expense_accounts):
+    return asset_accounts + expense_accounts
+
+
+@pytest.fixture
+def categories():
+    return [
+        {"id": "cat-1", "attributes": {"name": "supermercado"}},
+        {"id": "cat-2", "attributes": {"name": "transporte"}},
+    ]
+
+
+@pytest.fixture
+def budgets():
+    return [
+        {"id": "budget-1", "attributes": {"name": "comida"}},
+        {"id": "budget-2", "attributes": {"name": "mensual"}},
+    ]
+
+
+@pytest.fixture
+def transactions():
+    return [
+        {
+            "attributes": {
+                "transactions": [
+                    {
+                        "date": "2026-04-27T10:00:00+00:00",
+                        "description": "supermercado pingo doce",
+                        "amount": "-12.55",
+                    }
+                ]
+            }
+        }
+    ]
+
+
+def button_texts(reply):
+    markup = reply.get("reply_markup")
+    if not markup:
+        return []
+    return [
+        button.text
+        for row in markup.inline_keyboard
+        for button in row
+    ]

--- a/tests/test_client_cache_middleware.py
+++ b/tests/test_client_cache_middleware.py
@@ -1,0 +1,137 @@
+import time
+
+import pytest
+import requests
+
+from bot import client, middleware
+from bot.cache import TTLCache
+from bot.handlers import expense
+from tests.conftest import FakeCallbackQuery, FakeContext, FakeMessage, FakeResponse, FakeUpdate, button_texts
+
+
+def test_ttl_cache_get_set_expire_invalidate_clear():
+    cache = TTLCache(default_ttl=1)
+    assert cache.get("missing") is None
+
+    cache.set("key", "value")
+    assert cache.get("key") == "value"
+
+    cache.set("expired", "value", ttl=-1)
+    assert cache.get("expired") is None
+
+    cache.invalidate("key")
+    assert cache.get("key") is None
+
+    cache.set("a", 1)
+    cache.clear()
+    assert cache.get("a") is None
+
+
+def test_safe_get_success_timeout_and_error(monkeypatch):
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse({"data": [{"id": "1"}]}),
+    )
+    assert client.safe_get("/ok") == [{"id": "1"}]
+
+    def timeout(*args, **kwargs):
+        raise requests.exceptions.Timeout()
+
+    monkeypatch.setattr(client.requests, "get", timeout)
+    assert client.safe_get("/timeout") == []
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(client.requests, "get", boom)
+    assert client.safe_get("/boom") == []
+
+
+def test_get_accounts_uses_cache_and_local_filter_fallback(monkeypatch, all_accounts):
+    local_cache = TTLCache(default_ttl=60)
+    monkeypatch.setattr(client, "cache", local_cache)
+
+    calls = []
+
+    def fake_safe_get(endpoint, params=None):
+        calls.append(params)
+        if params and params.get("type") == "asset":
+            return []
+        return all_accounts
+
+    monkeypatch.setattr(client, "safe_get", fake_safe_get)
+
+    accounts = client.get_accounts("asset")
+    assert [a["id"] for a in accounts] == ["asset-1", "asset-2"]
+    assert len(calls) == 2
+
+    cached = client.get_accounts("asset")
+    assert cached == accounts
+    assert len(calls) == 2
+
+
+def test_refresh_cache_clears_cache(monkeypatch):
+    local_cache = TTLCache(default_ttl=60)
+    local_cache.set("x", "y")
+    monkeypatch.setattr(client, "cache", local_cache)
+
+    client.refresh_cache()
+
+    assert local_cache.get("x") is None
+
+
+@pytest.mark.asyncio
+async def test_auth_open_allowed_and_denied(monkeypatch):
+    monkeypatch.setattr(middleware, "ALLOWED_USER_IDS", [])
+    assert await middleware.require_auth(FakeUpdate(message=FakeMessage(), user_id=1), FakeContext())
+
+    monkeypatch.setattr(middleware, "ALLOWED_USER_IDS", [1])
+    assert await middleware.require_auth(FakeUpdate(message=FakeMessage(), user_id=1), FakeContext())
+
+    denied_message = FakeMessage()
+    assert not await middleware.require_auth(
+        FakeUpdate(message=denied_message, user_id=2), FakeContext()
+    )
+    assert "No estás autorizado" in denied_message.replies[-1]["text"]
+
+    denied_query = FakeCallbackQuery("x")
+    assert not await middleware.require_auth(
+        FakeUpdate(callback_query=denied_query, user_id=2), FakeContext()
+    )
+    assert denied_query.answers[-1]["show_alert"] is True
+
+
+def test_validation_helpers():
+    assert middleware.sanitize_text("  abc  ", 2) == "ab"
+    assert middleware.validate_amount("12,55") == 12.55
+    assert middleware.validate_amount("nope") is None
+
+
+def test_keyboard_and_summary_helpers(expense_accounts):
+    context = FakeContext(user_data={"recent_destinations": ["uber"]})
+
+    destination_rows = expense._build_destination_keyboard(expense_accounts, context)
+    destination_buttons = [button.text for row in destination_rows for button in row]
+    assert "🕐 uber" in destination_buttons
+    assert "⏭️ Sin cuenta destino" in destination_buttons
+
+    category_buttons = [button.text for row in expense._build_category_keyboard([]) for button in row]
+    assert "⏭️ Sin categoría" in category_buttons
+
+    markup = expense._get_keyboard_with_cancel([])
+    assert "❌ Cancelar" in [button.text for row in markup.inline_keyboard for button in row]
+
+    summary = expense._build_confirmation_summary(
+        {
+            "amount": 12.55,
+            "description": "supermercado pingo doce",
+            "origin": "tarjeta",
+            "destination": None,
+            "category": None,
+            "budget": None,
+            "tags": [],
+        }
+    )
+    assert "supermercado pingo doce" in summary
+    assert "_Sin cuenta destino_" in summary

--- a/tests/test_expense_flow.py
+++ b/tests/test_expense_flow.py
@@ -1,0 +1,319 @@
+import pytest
+from telegram.ext import ConversationHandler
+
+from bot.constants import (
+    SELECT_ORIGIN,
+    ENTER_AMOUNT_DESC,
+    SELECT_DESTINATION,
+    SELECT_CATEGORY,
+    SELECT_BUDGET,
+    ENTER_TAGS,
+    CONFIRM_EXPENSE,
+)
+from bot.handlers import expense, menu
+
+from tests.conftest import (
+    FakeCallbackQuery,
+    FakeContext,
+    FakeMessage,
+    FakeResponse,
+    FakeUpdate,
+    button_texts,
+)
+
+
+def patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets):
+    def fake_get_accounts(account_type=None, use_cache=True):
+        if account_type == "asset":
+            return [a for a in all_accounts if a["attributes"]["type"] == "asset"]
+        if account_type == "expense":
+            return expense_accounts
+        return all_accounts
+
+    monkeypatch.setattr(expense, "get_accounts", fake_get_accounts)
+    monkeypatch.setattr(expense, "get_categories", lambda: categories)
+    monkeypatch.setattr(expense, "get_budgets", lambda: budgets)
+
+
+@pytest.mark.asyncio
+async def test_menu_to_expense_full_flow_preserves_multi_word_description(
+    monkeypatch, all_accounts, expense_accounts, categories, budgets
+):
+    patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets)
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    context = FakeContext()
+
+    menu_message = FakeMessage("/menu")
+    await menu.start_menu(FakeUpdate(message=menu_message), context)
+    assert "💸 Registrar gasto" in button_texts(menu_message.replies[-1])
+
+    menu_query = FakeCallbackQuery("menu_expense")
+    state = await expense.start_expense_button(
+        FakeUpdate(callback_query=menu_query), context
+    )
+    assert state == SELECT_ORIGIN
+    assert "tarjeta" in button_texts(menu_query.message.replies[-1])
+
+    origin_query = FakeCallbackQuery("origin::tarjeta")
+    state = await expense.select_origin(FakeUpdate(callback_query=origin_query), context)
+    assert state == ENTER_AMOUNT_DESC
+
+    amount_message = FakeMessage("12.55 supermercado pingo doce")
+    state = await expense.enter_amount_description(
+        FakeUpdate(message=amount_message), context
+    )
+    assert state == SELECT_DESTINATION
+    assert context.user_data["amount"] == 12.55
+    assert context.user_data["description"] == "supermercado pingo doce"
+
+    dest_query = FakeCallbackQuery("dest::pingo doce")
+    state = await expense.select_destination(FakeUpdate(callback_query=dest_query), context)
+    assert state == SELECT_CATEGORY
+
+    cat_query = FakeCallbackQuery("cat::supermercado")
+    state = await expense.select_category(FakeUpdate(callback_query=cat_query), context)
+    assert state == SELECT_BUDGET
+
+    budget_query = FakeCallbackQuery("budget::comida")
+    state = await expense.select_budget(FakeUpdate(callback_query=budget_query), context)
+    assert state == ENTER_TAGS
+    assert "⏭️ Sin tags" in button_texts(budget_query.message.replies[-1])
+
+    tags_query = FakeCallbackQuery("tags::none")
+    state = await expense.skip_tags(FakeUpdate(callback_query=tags_query), context)
+    assert state == CONFIRM_EXPENSE
+    assert "supermercado pingo doce" in tags_query.message.replies[-1]["text"]
+
+    confirm_query = FakeCallbackQuery("confirm_expense")
+    state = await expense.confirm_expense(FakeUpdate(callback_query=confirm_query), context)
+    assert state == ConversationHandler.END
+
+    assert len(created_payloads) == 1
+    transaction = created_payloads[0]["transactions"][0]
+    assert transaction["type"] == "withdrawal"
+    assert transaction["amount"] == "12.55"
+    assert transaction["description"] == "supermercado pingo doce"
+    assert transaction["source_id"] == "asset-1"
+    assert transaction["destination_id"] == "expense-1"
+    assert transaction["category_id"] == "cat-1"
+    assert transaction["budget_id"] == "budget-1"
+    assert "date" in transaction
+    assert "Gasto registrado correctamente" in confirm_query.message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_expense_button_flow_allows_optional_skips(
+    monkeypatch, all_accounts, expense_accounts
+):
+    patch_expense_data(monkeypatch, all_accounts, expense_accounts, [], [])
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    context = FakeContext()
+    assert await expense.select_origin(
+        FakeUpdate(callback_query=FakeCallbackQuery("origin::tarjeta")), context
+    ) == ENTER_AMOUNT_DESC
+    assert await expense.enter_amount_description(
+        FakeUpdate(message=FakeMessage("8 cafe")), context
+    ) == SELECT_DESTINATION
+    assert await expense.select_destination(
+        FakeUpdate(callback_query=FakeCallbackQuery("dest::none")), context
+    ) == ENTER_TAGS
+    assert await expense.skip_tags(
+        FakeUpdate(callback_query=FakeCallbackQuery("tags::none")), context
+    ) == CONFIRM_EXPENSE
+    assert await expense.confirm_expense(
+        FakeUpdate(callback_query=FakeCallbackQuery("confirm_expense")), context
+    ) == ConversationHandler.END
+
+    transaction = created_payloads[0]["transactions"][0]
+    assert "destination_id" not in transaction
+    assert "category_id" not in transaction
+    assert "budget_id" not in transaction
+    assert "tags" not in transaction
+
+
+@pytest.mark.asyncio
+async def test_expense_button_flow_can_create_new_destination(
+    monkeypatch, all_accounts, expense_accounts, categories, budgets
+):
+    created_account = {"id": "expense-3", "attributes": {"name": "nuevo mercado", "type": "expense"}}
+    accounts_after_create = all_accounts + [created_account]
+
+    patch_expense_data(monkeypatch, accounts_after_create, expense_accounts, categories, budgets)
+    monkeypatch.setattr(
+        expense,
+        "create_account",
+        lambda name: FakeResponse({"data": {"attributes": {"name": name}}}),
+    )
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    context = FakeContext({"user_data": {}})
+    context.user_data["amount"] = 20.0
+    context.user_data["description"] = "compra"
+    context.user_data["origin"] = "tarjeta"
+
+    assert await expense.select_destination(
+        FakeUpdate(callback_query=FakeCallbackQuery("dest::new")), context
+    )
+    assert await expense.enter_new_dest_name(
+        FakeUpdate(message=FakeMessage("nuevo mercado")), context
+    ) == SELECT_CATEGORY
+    assert context.user_data["destination"] == "nuevo mercado"
+    assert context.user_data["recent_destinations"] == ["nuevo mercado"]
+
+    context.user_data["category"] = None
+    context.user_data["budget"] = None
+    context.user_data["tags"] = []
+    await expense._create_expense_transaction(FakeMessage(), context)
+    assert created_payloads[0]["transactions"][0]["destination_id"] == "expense-3"
+
+
+@pytest.mark.asyncio
+async def test_invalid_amount_stays_in_amount_step(monkeypatch):
+    called = False
+    monkeypatch.setattr(expense, "create_transaction", lambda payload: called)
+    context = FakeContext()
+    message = FakeMessage("nope")
+
+    state = await expense.enter_amount_description(FakeUpdate(message=message), context)
+
+    assert state == ENTER_AMOUNT_DESC
+    assert "Monto inválido" in message.replies[-1]["text"]
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_amount_only_requires_amount_and_description_together(monkeypatch):
+    context = FakeContext()
+
+    first = FakeMessage("12.55")
+    assert await expense.enter_amount_description(FakeUpdate(message=first), context) == ENTER_AMOUNT_DESC
+    assert "monto y la descripción juntos" in first.replies[-1]["text"]
+    assert "amount" not in context.user_data
+    assert "awaiting_description" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_quick_expense_validation_responses(monkeypatch, all_accounts):
+    monkeypatch.setattr(expense, "get_accounts", lambda *args, **kwargs: all_accounts)
+
+    no_args = FakeMessage("/gasto")
+    await expense.quick_expense(FakeUpdate(message=no_args), FakeContext(args=[]))
+    assert "Registrar gasto rápido" in no_args.replies[-1]["text"]
+
+    few_args = FakeMessage("/gasto 12")
+    await expense.quick_expense(FakeUpdate(message=few_args), FakeContext(args=["12"]))
+    assert "Faltan argumentos" in few_args.replies[-1]["text"]
+
+    bad_amount = FakeMessage("/gasto nope cafe tarjeta")
+    await expense.quick_expense(
+        FakeUpdate(message=bad_amount), FakeContext(args=["nope", "cafe", "tarjeta"])
+    )
+    assert "Monto inválido" in bad_amount.replies[-1]["text"]
+
+    missing_origin = FakeMessage("/gasto 12 cafe inexistente")
+    await expense.quick_expense(
+        FakeUpdate(message=missing_origin), FakeContext(args=["12", "cafe", "inexistente"])
+    )
+    assert "Cuenta de origen 'inexistente' no encontrada" in missing_origin.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_quick_expense_creates_minimal_transaction(monkeypatch, all_accounts):
+    monkeypatch.setattr(expense, "get_accounts", lambda *args, **kwargs: all_accounts)
+    monkeypatch.setattr(expense, "get_categories", lambda: [])
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    message = FakeMessage("/gasto 12 cafe tarjeta")
+    context = FakeContext(args=["12", "cafe", "tarjeta"])
+    await expense.quick_expense(FakeUpdate(message=message), context)
+
+    transaction = created_payloads[0]["transactions"][0]
+    assert transaction["amount"] == "12.0"
+    assert transaction["description"] == "cafe"
+    assert transaction["source_id"] == "asset-1"
+    assert "Gasto registrado" in message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_quick_expense_applies_existing_category_and_destination(
+    monkeypatch, all_accounts, categories
+):
+    monkeypatch.setattr(expense, "get_accounts", lambda *args, **kwargs: all_accounts)
+    monkeypatch.setattr(expense, "get_categories", lambda: categories)
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    message = FakeMessage("/gasto 12 cafe tarjeta supermercado pingo doce")
+    await expense.quick_expense(
+        FakeUpdate(message=message),
+        FakeContext(args=["12", "cafe", "tarjeta", "supermercado", "pingo doce"]),
+    )
+
+    transaction = created_payloads[0]["transactions"][0]
+    assert transaction["category_id"] == "cat-1"
+    assert transaction["destination_id"] == "expense-1"
+
+
+@pytest.mark.asyncio
+async def test_quick_expense_documents_multi_word_description_gap(monkeypatch, all_accounts):
+    monkeypatch.setattr(expense, "get_accounts", lambda *args, **kwargs: all_accounts)
+    monkeypatch.setattr(expense, "get_categories", lambda: [])
+    created_payloads = []
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: created_payloads.append(payload) or FakeResponse(),
+    )
+
+    message = FakeMessage("/gasto 12.55 supermercado pingo doce tarjeta")
+    await expense.quick_expense(
+        FakeUpdate(message=message),
+        FakeContext(args=["12.55", "supermercado", "pingo", "doce", "tarjeta"]),
+    )
+
+    assert created_payloads == []
+    assert "Cuenta de origen 'pingo' no encontrada" in message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_quick_expense_firefly_error(monkeypatch, all_accounts):
+    monkeypatch.setattr(expense, "get_accounts", lambda *args, **kwargs: all_accounts)
+    monkeypatch.setattr(expense, "get_categories", lambda: [])
+    monkeypatch.setattr(
+        expense,
+        "create_transaction",
+        lambda payload: FakeResponse(status_error=RuntimeError("boom")),
+    )
+
+    message = FakeMessage("/gasto 12 cafe tarjeta")
+    await expense.quick_expense(
+        FakeUpdate(message=message), FakeContext(args=["12", "cafe", "tarjeta"])
+    )
+
+    assert "Error al registrar el gasto" in message.replies[-1]["text"]

--- a/tests/test_menu_assets_account.py
+++ b/tests/test_menu_assets_account.py
@@ -1,0 +1,119 @@
+import pytest
+
+from bot.handlers import account, assets, common, menu
+from tests.conftest import FakeCallbackQuery, FakeContext, FakeMessage, FakeUpdate, button_texts
+
+
+@pytest.mark.asyncio
+async def test_start_and_menu_show_main_keyboard():
+    message = FakeMessage("/start")
+
+    await menu.start_menu(FakeUpdate(message=message), FakeContext())
+
+    buttons = button_texts(message.replies[-1])
+    assert "💸 Registrar gasto" in buttons
+    assert "💼 Ver cuentas" in buttons
+    assert "📊 Ver cuenta + movimientos" in buttons
+    assert "📋 Ver comandos" in buttons
+
+
+@pytest.mark.asyncio
+async def test_menu_callbacks_route_to_assets_and_commands(monkeypatch, asset_accounts):
+    monkeypatch.setattr(assets, "get_accounts", lambda account_type=None: asset_accounts)
+
+    assets_query = FakeCallbackQuery("menu_assets")
+    await menu.handle_menu_selection(FakeUpdate(callback_query=assets_query), FakeContext())
+    assert "Tus cuentas de activo" in assets_query.message.replies[-1]["text"]
+
+    commands_query = FakeCallbackQuery("menu_commands")
+    await menu.handle_menu_selection(FakeUpdate(callback_query=commands_query), FakeContext())
+    assert "Comandos disponibles" in commands_query.message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_assets_lists_visible_accounts_and_hides_configured(monkeypatch, asset_accounts):
+    monkeypatch.setattr(assets, "get_accounts", lambda account_type=None: asset_accounts)
+    monkeypatch.setattr(assets, "OCULTAR_CUENTAS_LOWER", ["efectivo"])
+
+    message = FakeMessage("/assets")
+    await assets.list_assets(FakeUpdate(message=message), FakeContext())
+
+    buttons = button_texts(message.replies[-1])
+    assert "tarjeta" in buttons
+    assert "efectivo" not in buttons
+
+
+@pytest.mark.asyncio
+async def test_assets_handles_empty_and_errors(monkeypatch):
+    monkeypatch.setattr(assets, "get_accounts", lambda account_type=None: [])
+    empty = FakeMessage("/assets")
+    await assets.list_assets(FakeUpdate(message=empty), FakeContext())
+    assert "No hay cuentas visibles" in empty.replies[-1]["text"]
+
+    def boom(account_type=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(assets, "get_accounts", boom)
+    error = FakeMessage("/assets")
+    await assets.list_assets(FakeUpdate(message=error), FakeContext())
+    assert "No se pudo obtener" in error.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_show_account_validation_and_success(monkeypatch):
+    no_name = FakeMessage("/cuenta")
+    await account.show_account(FakeUpdate(message=no_name), FakeContext())
+    assert "Uso: /cuenta" in no_name.replies[-1]["text"]
+
+    bad_count = FakeMessage("/cuenta tarjeta nope")
+    await account.show_account(FakeUpdate(message=bad_count), FakeContext())
+    assert "Cantidad de movimientos inválida" in bad_count.replies[-1]["text"]
+
+    async def found_display(name, limit=3):
+        return "ok"
+
+    monkeypatch.setattr(account, "format_account_display", found_display)
+    found = FakeMessage("/cuenta tarjeta 2")
+    await account.show_account(FakeUpdate(message=found), FakeContext())
+    assert found.replies[-1]["text"] == "ok"
+
+    async def missing_display(name, limit=3):
+        return None
+
+    monkeypatch.setattr(account, "format_account_display", missing_display)
+    missing = FakeMessage("/cuenta missing")
+    await account.show_account(FakeUpdate(message=missing), FakeContext())
+    assert "Cuenta no encontrada" in missing.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_format_account_display(monkeypatch, all_accounts, transactions):
+    monkeypatch.setattr(common, "get_accounts", lambda: all_accounts)
+    monkeypatch.setattr(common, "safe_get", lambda endpoint, params=None: transactions)
+
+    result = await common.format_account_display("tarjeta", limit=3)
+
+    assert "📊 *tarjeta*" in result
+    assert "Balance: 100.00" in result
+    assert "supermercado pingo doce" in result
+
+
+def test_split_message_prefers_newline():
+    text = "a\n" + ("b" * 10)
+    chunks = account._split_message(text, max_length=5)
+    assert chunks == ["a", "bbbbb", "bbbbb"]
+
+
+@pytest.mark.asyncio
+async def test_account_callback_and_catch_all(monkeypatch):
+    async def callback_display(name, limit=3):
+        return "account ok"
+
+    monkeypatch.setattr(account, "format_account_display", callback_display)
+    query = FakeCallbackQuery("cuenta::tarjeta")
+    await account.handle_callback(FakeUpdate(callback_query=query), FakeContext())
+    assert query.message.replies[-1]["text"] == "account ok"
+
+    reserved = FakeCallbackQuery("origin::tarjeta")
+    await account.handle_callback(FakeUpdate(callback_query=reserved), FakeContext())
+    assert reserved.message.replies == []


### PR DESCRIPTION
Closes #16

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds an inline skip-tags button to reduce expense flow friction.
- Requires amount and description together, removing the unsupported delayed-description prompt.
- Adds pytest coverage for the critical menu → expense registration → confirm flow and supporting bot behavior.

## Changes
| File | Change |
|------|--------|
| `bot/handlers/expense.py` | Adds skip-tags callback and simplifies amount/description prompt behavior. |
| `tests/` | Adds fake Telegram/Firefly helpers and 25 tests across expense, menu, assets, account, client, cache, middleware, and helpers. |
| `.github/workflows/ci-compile.yml` | Installs dependencies, compiles app/tests, and runs pytest. |
| `requirements.txt`, `pytest.ini` | Adds pytest dependencies and restricts test discovery to project tests. |

## Test Plan
- [x] Ran compile check: `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile run.py bot/*.py bot/handlers/*.py tests/*.py`
- [x] Ran tests: `.venv/bin/python -m pytest` — 25 passed
- [x] Verified critical flow test covers `/menu` → `💸 Registrar gasto` → full registration → confirm with `12.55 supermercado pingo doce`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts — N/A, no shell scripts modified
- [x] Skills tested in at least one agent — N/A, no skills modified
- [x] Docs updated if behavior changed — release docs unchanged; behavior covered by tests
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
