### PR TITLE
feat(menu): show pending subscriptions

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -113,6 +113,23 @@ def get_bills(use_cache: bool = True) -> list:
     return bills
 
 
+def get_bills_for_period(start: str, end: str, use_cache: bool = False) -> list:
+    """Get bills for a specific Firefly III period with optional period cache."""
+    cache_key = f"bills:{start}:{end}"
+    if use_cache:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    bills = safe_get(
+        "/api/v1/bills",
+        params={"start": start, "end": end, "limit": 100},
+    )
+    if use_cache and bills:
+        cache.set(cache_key, bills)
+    return bills
+
+
 def create_transaction(payload: dict) -> requests.Response:
     """Create a new transaction in Firefly III."""
     return safe_post("/api/v1/transactions", payload)

--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -3,6 +3,7 @@ from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
 
 from bot.handlers.common import list_commands
 from bot.handlers.assets import show_assets
+from bot.handlers import subscriptions
 from bot.middleware import require_auth
 
 
@@ -15,6 +16,7 @@ async def start_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton("🔁 Transferir", callback_data="menu_transfer")],
         [InlineKeyboardButton("💼 Ver cuentas", callback_data="menu_assets")],
         [InlineKeyboardButton("📊 Ver cuenta + movimientos", callback_data="menu_cuenta")],
+        [InlineKeyboardButton("🧾 Suscripciones pendientes", callback_data="menu_subscriptions")],
         [InlineKeyboardButton("📋 Ver comandos", callback_data="menu_commands")]
     ]
     await update.message.reply_text("¿Qué querés hacer?", reply_markup=InlineKeyboardMarkup(keyboard))
@@ -37,6 +39,8 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
         await show_assets(update, context)
     elif data == "menu_commands":
         await list_commands(query, context)
+    elif data == "menu_subscriptions":
+        await subscriptions.show_current_period_subscriptions(update, context)
 
 
 menu_handlers = [
@@ -44,5 +48,5 @@ menu_handlers = [
     CommandHandler("menu", start_menu),
     # `menu_expense` and `menu_transfer` are intentionally handled by
     # ConversationHandlers so the dedicated flows own their state transitions.
-    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands)$")
+    CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands|menu_subscriptions)$")
 ]

--- a/bot/handlers/subscriptions.py
+++ b/bot/handlers/subscriptions.py
@@ -1,0 +1,113 @@
+import logging
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
+
+import pytz
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from bot import client
+from bot.config import TIMEZONE
+
+
+EMPTY_SUBSCRIPTIONS_MESSAGE = "✅ No tenés suscripciones pendientes en el período actual."
+SUBSCRIPTIONS_ERROR_MESSAGE = "No se pudieron obtener las suscripciones pendientes ahora."
+
+
+def get_current_period_bounds() -> tuple[str, str]:
+    """Return current local month boundaries as Firefly YYYY-MM-DD strings."""
+    timezone = pytz.timezone(TIMEZONE)
+    today = datetime.now(timezone).date()
+    start = today.replace(day=1)
+    if start.month == 12:
+        next_month = start.replace(year=start.year + 1, month=1)
+    else:
+        next_month = start.replace(month=start.month + 1)
+    end = next_month - timedelta(days=1)
+    return start.isoformat(), end.isoformat()
+
+
+def _normalize_date(value) -> str | None:
+    if isinstance(value, dict):
+        value = value.get("date")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()[:10]
+
+
+def _normalized_dates(values) -> set[str]:
+    if not isinstance(values, list):
+        return set()
+    return {date for date in (_normalize_date(value) for value in values) if date}
+
+
+def _format_amount(attributes: dict) -> str:
+    amount_min = attributes.get("amount_min")
+    amount_max = attributes.get("amount_max")
+    currency = attributes.get("currency_symbol") or attributes.get("currency_code") or ""
+    suffix = f" {currency}" if currency else ""
+
+    if not amount_min or _parse_amount(amount_min) is None:
+        return "monto no disponible"
+    if amount_max and amount_max != amount_min and _parse_amount(amount_max) is not None:
+        return f"{amount_min} - {amount_max}{suffix}"
+    return f"{amount_min}{suffix}"
+
+
+def _parse_amount(value: str) -> Decimal | None:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def extract_pending_subscriptions(bills: list, start: str, end: str) -> list[dict]:
+    """Extract unpaid subscription due instances inside inclusive period bounds."""
+    pending = []
+    for bill in bills:
+        if not isinstance(bill, dict):
+            continue
+        attributes = bill.get("attributes")
+        if not isinstance(attributes, dict):
+            continue
+        name = attributes.get("name")
+        if attributes.get("active") is not True or not name:
+            continue
+
+        paid_dates = _normalized_dates(attributes.get("paid_dates", []))
+        for due_date in sorted(_normalized_dates(attributes.get("pay_dates", []))):
+            if start <= due_date <= end and due_date not in paid_dates:
+                pending.append(
+                    {
+                        "name": name,
+                        "due_date": due_date,
+                        "amount": _format_amount(attributes),
+                    }
+                )
+    return sorted(pending, key=lambda item: (item["due_date"], item["name"]))
+
+
+def build_pending_subscriptions_message(bills: list, start: str, end: str) -> str:
+    pending = extract_pending_subscriptions(bills, start, end)
+    if not pending:
+        return EMPTY_SUBSCRIPTIONS_MESSAGE
+
+    lines = ["Suscripciones pendientes del período actual:"]
+    lines.extend(
+        f"• {item['name']} — vence {item['due_date']} — {item['amount']}"
+        for item in pending
+    )
+    return "\n".join(lines)
+
+
+async def show_current_period_subscriptions(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        start, end = get_current_period_bounds()
+        bills = client.get_bills_for_period(start, end)
+        message = build_pending_subscriptions_message(bills, start, end)
+    except Exception:
+        logging.exception("Error obteniendo suscripciones pendientes")
+        message = SUBSCRIPTIONS_ERROR_MESSAGE
+
+    target = update.callback_query.message if update.callback_query else update.message
+    await target.reply_text(message)

--- a/bot/handlers/subscriptions.py
+++ b/bot/handlers/subscriptions.py
@@ -12,6 +12,7 @@ from bot.config import TIMEZONE
 
 EMPTY_SUBSCRIPTIONS_MESSAGE = "✅ No tenés suscripciones pendientes en el período actual."
 SUBSCRIPTIONS_ERROR_MESSAGE = "No se pudieron obtener las suscripciones pendientes ahora."
+PAYMENT_DATE_GRACE_DAYS = 7
 
 
 def get_current_period_bounds() -> tuple[str, str]:
@@ -39,6 +40,40 @@ def _normalized_dates(values) -> set[str]:
     if not isinstance(values, list):
         return set()
     return {date for date in (_normalize_date(value) for value in values) if date}
+
+
+def _parse_date(value: str):
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _matched_paid_due_dates(due_dates: set[str], paid_dates: set[str]) -> set[str]:
+    candidates = []
+    for due_date in due_dates:
+        due = _parse_date(due_date)
+        if not due:
+            if due_date in paid_dates:
+                candidates.append((0, due_date, due_date))
+            continue
+
+        for paid_date in paid_dates:
+            paid = _parse_date(paid_date)
+            if not paid:
+                continue
+            distance = abs((paid - due).days)
+            if distance <= PAYMENT_DATE_GRACE_DAYS:
+                candidates.append((distance, due_date, paid_date))
+
+    matched_due_dates = set()
+    matched_paid_dates = set()
+    for _, due_date, paid_date in sorted(candidates):
+        if due_date in matched_due_dates or paid_date in matched_paid_dates:
+            continue
+        matched_due_dates.add(due_date)
+        matched_paid_dates.add(paid_date)
+    return matched_due_dates
 
 
 def _format_amount(attributes: dict) -> str:
@@ -74,9 +109,13 @@ def extract_pending_subscriptions(bills: list, start: str, end: str) -> list[dic
         if attributes.get("active") is not True or not name:
             continue
 
-        paid_dates = _normalized_dates(attributes.get("paid_dates", []))
-        for due_date in sorted(_normalized_dates(attributes.get("pay_dates", []))):
-            if start <= due_date <= end and due_date not in paid_dates:
+        due_dates = _normalized_dates(attributes.get("pay_dates", []))
+        matched_paid_due_dates = _matched_paid_due_dates(
+            due_dates,
+            _normalized_dates(attributes.get("paid_dates", [])),
+        )
+        for due_date in sorted(due_dates):
+            if start <= due_date <= end and due_date not in matched_paid_due_dates:
                 pending.append(
                     {
                         "name": name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,80 @@ def mixed_bills(bills):
 
 
 @pytest.fixture
+def subscription_bills():
+    return [
+        {
+            "id": "bill-active-unpaid-string",
+            "attributes": {
+                "name": "Netflix *unsafe* [name]",
+                "active": True,
+                "pay_dates": ["2026-05-04"],
+                "paid_dates": [],
+                "amount_min": "10.00",
+                "amount_max": "10.00",
+                "currency_symbol": "€",
+            },
+        },
+        {
+            "id": "bill-active-unpaid-dict",
+            "attributes": {
+                "name": "Internet",
+                "active": True,
+                "pay_dates": [{"date": "2026-05-14T12:30:00+00:00"}],
+                "paid_dates": [],
+                "amount_min": "20.00",
+                "amount_max": "25.50",
+                "currency_code": "EUR",
+            },
+        },
+        {
+            "id": "bill-paid",
+            "attributes": {
+                "name": "Gym",
+                "active": True,
+                "pay_dates": ["2026-05-20"],
+                "paid_dates": ["2026-05-20"],
+                "amount_min": "30.00",
+                "amount_max": "30.00",
+                "currency_code": "EUR",
+            },
+        },
+        {
+            "id": "bill-out-of-period",
+            "attributes": {
+                "name": "Cloud",
+                "active": True,
+                "pay_dates": ["2026-06-01"],
+                "paid_dates": [],
+                "amount_min": "7.00",
+                "amount_max": "7.00",
+                "currency_code": "EUR",
+            },
+        },
+        {
+            "id": "bill-inactive",
+            "attributes": {
+                "name": "Old service",
+                "active": False,
+                "pay_dates": ["2026-05-10"],
+                "paid_dates": [],
+            },
+        },
+        {
+            "id": "bill-missing-amount",
+            "attributes": {
+                "name": "Unknown amount",
+                "active": True,
+                "pay_dates": ["2026-05-22"],
+                "paid_dates": [],
+            },
+        },
+        {"id": "broken-attributes", "attributes": "bad"},
+        "not-a-bill",
+    ]
+
+
+@pytest.fixture
 def transactions():
     return [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,30 @@ def subscription_bills():
             },
         },
         {
+            "id": "bill-paid-early",
+            "attributes": {
+                "name": "Rent",
+                "active": True,
+                "pay_dates": ["2026-05-01"],
+                "paid_dates": ["2026-04-30"],
+                "amount_min": "800.00",
+                "amount_max": "800.00",
+                "currency_code": "EUR",
+            },
+        },
+        {
+            "id": "bill-paid-late",
+            "attributes": {
+                "name": "Insurance",
+                "active": True,
+                "pay_dates": ["2026-05-10"],
+                "paid_dates": ["2026-05-12"],
+                "amount_min": "50.00",
+                "amount_max": "50.00",
+                "currency_code": "EUR",
+            },
+        },
+        {
             "id": "bill-out-of-period",
             "attributes": {
                 "name": "Cloud",

--- a/tests/test_client_cache_middleware.py
+++ b/tests/test_client_cache_middleware.py
@@ -98,6 +98,51 @@ def test_get_bills_uses_cache(monkeypatch, bills):
     assert calls == [("/api/v1/bills", {"limit": 100})]
 
 
+def test_get_bills_for_period_sends_start_end_and_limit(monkeypatch, bills):
+    calls = []
+
+    def fake_safe_get(endpoint, params=None):
+        calls.append((endpoint, params))
+        return bills
+
+    monkeypatch.setattr(client, "safe_get", fake_safe_get)
+
+    result = client.get_bills_for_period("2026-05-01", "2026-05-31")
+
+    assert result == bills
+    assert calls == [
+        (
+            "/api/v1/bills",
+            {"start": "2026-05-01", "end": "2026-05-31", "limit": 100},
+        )
+    ]
+
+
+def test_get_bills_for_period_cache_is_optional_and_isolated(monkeypatch, bills):
+    local_cache = TTLCache(default_ttl=60)
+    monkeypatch.setattr(client, "cache", local_cache)
+    calls = []
+
+    def fake_safe_get(endpoint, params=None):
+        calls.append(params)
+        return bills
+
+    monkeypatch.setattr(client, "safe_get", fake_safe_get)
+
+    assert client.get_bills_for_period("2026-05-01", "2026-05-31") == bills
+    assert client.get_bills_for_period("2026-05-01", "2026-05-31") == bills
+    assert len(calls) == 2
+    assert local_cache.get("bills:2026-05-01:2026-05-31") is None
+
+    assert client.get_bills_for_period("2026-05-01", "2026-05-31", use_cache=True) == bills
+    assert client.get_bills_for_period("2026-05-01", "2026-05-31", use_cache=True) == bills
+    assert len(calls) == 3
+    assert local_cache.get("bills:2026-05-01:2026-05-31") == bills
+
+    assert client.get_bills() == bills
+    assert local_cache.get("bills") == bills
+
+
 @pytest.mark.asyncio
 async def test_auth_open_allowed_and_denied(monkeypatch):
     monkeypatch.setattr(middleware, "ALLOWED_USER_IDS", [])

--- a/tests/test_menu_assets_account.py
+++ b/tests/test_menu_assets_account.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bot.handlers import account, assets, common, menu
+from bot.handlers import account, assets, common, menu, subscriptions
 from tests.conftest import FakeCallbackQuery, FakeContext, FakeMessage, FakeUpdate, button_texts
 
 
@@ -15,6 +15,7 @@ async def test_start_and_menu_show_main_keyboard():
     assert "🔁 Transferir" in buttons
     assert "💼 Ver cuentas" in buttons
     assert "📊 Ver cuenta + movimientos" in buttons
+    assert "🧾 Suscripciones pendientes" in buttons
     assert "📋 Ver comandos" in buttons
 
 
@@ -29,6 +30,31 @@ async def test_menu_callbacks_route_to_assets_and_commands(monkeypatch, asset_ac
     commands_query = FakeCallbackQuery("menu_commands")
     await menu.handle_menu_selection(FakeUpdate(callback_query=commands_query), FakeContext())
     assert "Comandos disponibles" in commands_query.message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_menu_subscriptions_callback_routes_without_flow_side_effects(monkeypatch):
+    calls = []
+
+    async def fake_show_current_period_subscriptions(update, context):
+        calls.append((update, context))
+        await update.callback_query.message.reply_text("subscriptions ok")
+
+    monkeypatch.setattr(
+        subscriptions,
+        "show_current_period_subscriptions",
+        fake_show_current_period_subscriptions,
+    )
+
+    query = FakeCallbackQuery("menu_subscriptions")
+    context = FakeContext(user_data={"existing": "value"})
+
+    await menu.handle_menu_selection(FakeUpdate(callback_query=query), context)
+
+    assert query.answers == [{"text": None}]
+    assert query.message.replies[-1]["text"] == "subscriptions ok"
+    assert calls[0][1] is context
+    assert context.user_data == {"existing": "value"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -37,6 +37,8 @@ def test_extract_pending_subscriptions_filters_unpaid_due_instances(subscription
         "2026-05-22",
     ]
     assert "Gym" not in [item["name"] for item in pending]
+    assert "Rent" not in [item["name"] for item in pending]
+    assert "Insurance" not in [item["name"] for item in pending]
     assert "Cloud" not in [item["name"] for item in pending]
     assert "Old service" not in [item["name"] for item in pending]
 
@@ -53,6 +55,8 @@ def test_build_pending_subscriptions_message_formats_amounts_and_plain_text(subs
     assert "• Internet — vence 2026-05-14 — 20.00 - 25.50 EUR" in message
     assert "• Unknown amount — vence 2026-05-22 — monto no disponible" in message
     assert "Gym" not in message
+    assert "Rent" not in message
+    assert "Insurance" not in message
 
 
 def test_build_pending_subscriptions_message_empty_state():
@@ -83,6 +87,58 @@ def test_build_pending_subscriptions_message_falls_back_for_invalid_amount():
     )
 
     assert "• Invalid amount — vence 2026-05-09 — monto no disponible" in message
+
+
+def test_extract_pending_subscriptions_keeps_payments_one_to_one():
+    bills = [
+        {
+            "attributes": {
+                "name": "Weekly service",
+                "active": True,
+                "pay_dates": ["2026-05-01", "2026-05-08"],
+                "paid_dates": ["2026-05-05"],
+                "amount_min": "5.00",
+                "amount_max": "5.00",
+                "currency_code": "EUR",
+            }
+        }
+    ]
+
+    pending = subscriptions.extract_pending_subscriptions(bills, "2026-05-01", "2026-05-31")
+
+    assert pending == [
+        {
+            "name": "Weekly service",
+            "due_date": "2026-05-01",
+            "amount": "5.00 EUR",
+        }
+    ]
+
+
+def test_extract_pending_subscriptions_keeps_out_of_grace_payments_pending():
+    bills = [
+        {
+            "attributes": {
+                "name": "Delayed service",
+                "active": True,
+                "pay_dates": ["2026-05-01"],
+                "paid_dates": ["2026-05-09"],
+                "amount_min": "15.00",
+                "amount_max": "15.00",
+                "currency_code": "EUR",
+            }
+        }
+    ]
+
+    pending = subscriptions.extract_pending_subscriptions(bills, "2026-05-01", "2026-05-31")
+
+    assert pending == [
+        {
+            "name": "Delayed service",
+            "due_date": "2026-05-01",
+            "amount": "15.00 EUR",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+
+import pytest
+
+from bot.handlers import subscriptions
+from tests.conftest import FakeCallbackQuery, FakeContext, FakeUpdate
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 2, 15, 12, 0, tzinfo=tz)
+
+
+def test_get_current_period_bounds_uses_configured_timezone_month_end(monkeypatch):
+    monkeypatch.setattr(subscriptions, "TIMEZONE", "Europe/Lisbon")
+    monkeypatch.setattr(subscriptions, "datetime", FixedDateTime)
+
+    assert subscriptions.get_current_period_bounds() == ("2026-02-01", "2026-02-28")
+
+
+def test_extract_pending_subscriptions_filters_unpaid_due_instances(subscription_bills):
+    pending = subscriptions.extract_pending_subscriptions(
+        subscription_bills,
+        "2026-05-01",
+        "2026-05-31",
+    )
+
+    assert [item["name"] for item in pending] == [
+        "Netflix *unsafe* [name]",
+        "Internet",
+        "Unknown amount",
+    ]
+    assert [item["due_date"] for item in pending] == [
+        "2026-05-04",
+        "2026-05-14",
+        "2026-05-22",
+    ]
+    assert "Gym" not in [item["name"] for item in pending]
+    assert "Cloud" not in [item["name"] for item in pending]
+    assert "Old service" not in [item["name"] for item in pending]
+
+
+def test_build_pending_subscriptions_message_formats_amounts_and_plain_text(subscription_bills):
+    message = subscriptions.build_pending_subscriptions_message(
+        subscription_bills,
+        "2026-05-01",
+        "2026-05-31",
+    )
+
+    assert "Suscripciones pendientes del período actual" in message
+    assert "• Netflix *unsafe* [name] — vence 2026-05-04 — 10.00 €" in message
+    assert "• Internet — vence 2026-05-14 — 20.00 - 25.50 EUR" in message
+    assert "• Unknown amount — vence 2026-05-22 — monto no disponible" in message
+    assert "Gym" not in message
+
+
+def test_build_pending_subscriptions_message_empty_state():
+    assert subscriptions.build_pending_subscriptions_message([], "2026-05-01", "2026-05-31") == (
+        "✅ No tenés suscripciones pendientes en el período actual."
+    )
+
+
+def test_build_pending_subscriptions_message_falls_back_for_invalid_amount():
+    bills = [
+        {
+            "attributes": {
+                "name": "Invalid amount",
+                "active": True,
+                "pay_dates": ["2026-05-09"],
+                "paid_dates": [],
+                "amount_min": "not-a-number",
+                "amount_max": "not-a-number",
+                "currency_code": "EUR",
+            }
+        }
+    ]
+
+    message = subscriptions.build_pending_subscriptions_message(
+        bills,
+        "2026-05-01",
+        "2026-05-31",
+    )
+
+    assert "• Invalid amount — vence 2026-05-09 — monto no disponible" in message
+
+
+@pytest.mark.asyncio
+async def test_show_current_period_subscriptions_replies_with_pending_bills(
+    monkeypatch,
+    subscription_bills,
+):
+    monkeypatch.setattr(
+        subscriptions,
+        "get_current_period_bounds",
+        lambda: ("2026-05-01", "2026-05-31"),
+    )
+    calls = []
+
+    def fake_get_bills_for_period(start, end):
+        calls.append((start, end))
+        return subscription_bills
+
+    monkeypatch.setattr(subscriptions.client, "get_bills_for_period", fake_get_bills_for_period)
+
+    query = FakeCallbackQuery("menu_subscriptions")
+    await subscriptions.show_current_period_subscriptions(
+        FakeUpdate(callback_query=query),
+        FakeContext(),
+    )
+
+    assert calls == [("2026-05-01", "2026-05-31")]
+    assert "Netflix *unsafe* [name]" in query.message.replies[-1]["text"]
+    assert "parse_mode" not in query.message.replies[-1]
+
+
+@pytest.mark.asyncio
+async def test_show_current_period_subscriptions_replies_empty_state(monkeypatch):
+    monkeypatch.setattr(
+        subscriptions,
+        "get_current_period_bounds",
+        lambda: ("2026-05-01", "2026-05-31"),
+    )
+    monkeypatch.setattr(subscriptions.client, "get_bills_for_period", lambda start, end: [])
+
+    query = FakeCallbackQuery("menu_subscriptions")
+    await subscriptions.show_current_period_subscriptions(
+        FakeUpdate(callback_query=query),
+        FakeContext(),
+    )
+
+    assert query.message.replies[-1]["text"] == "✅ No tenés suscripciones pendientes en el período actual."
+
+
+@pytest.mark.asyncio
+async def test_show_current_period_subscriptions_handles_client_exception(monkeypatch):
+    monkeypatch.setattr(
+        subscriptions,
+        "get_current_period_bounds",
+        lambda: ("2026-05-01", "2026-05-31"),
+    )
+
+    def boom(start, end):
+        raise RuntimeError("upstream failed")
+
+    monkeypatch.setattr(subscriptions.client, "get_bills_for_period", boom)
+
+    query = FakeCallbackQuery("menu_subscriptions")
+    await subscriptions.show_current_period_subscriptions(
+        FakeUpdate(callback_query=query),
+        FakeContext(),
+    )
+
+    assert query.message.replies[-1]["text"] == "No se pudieron obtener las suscripciones pendientes ahora."


### PR DESCRIPTION
Closes #25

## PR Type
- [x] New feature

## Summary
- Adds a /menu option to show current-period pending subscriptions.
- Lists due date and amount for unpaid Firefly bills.
- Adds defensive formatting, empty/error states, and test coverage.

## Changes
| File | Change |
|------|--------|
| `bot/client.py` | Adds period-aware Firefly bills retrieval. |
| `bot/handlers/subscriptions.py` | Adds pending subscription filtering, formatting, and Telegram handler. |
| `bot/handlers/menu.py` | Adds the subscriptions menu button and callback route. |
| `tests/conftest.py` | Adds subscription bill fixtures. |
| `tests/test_client_cache_middleware.py` | Covers period bill client behavior and cache keying. |
| `tests/test_menu_assets_account.py` | Covers menu button and callback wiring. |
| `tests/test_subscriptions.py` | Covers filtering, formatting, empty/error states, and handler behavior. |

## Test Plan
- [x] `PYTHONPYCACHEPREFIX=/tmp/pycache ./.venv/bin/python -m py_compile run.py bot/*.py bot/handlers/*.py tests/*.py`
- [x] `./.venv/bin/pytest tests/test_client_cache_middleware.py tests/test_subscriptions.py tests/test_menu_assets_account.py`
- [x] `./.venv/bin/pytest`

## Notes
- SDD artifacts are persisted in Engram under `sdd/menu-current-period-subscriptions/*`.
- Fresh-context review found no blocking issues; optional follow-up: pagination for users with more than 100 bills in a period.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] Tests included with the behavior
- [x] No secrets or local tokens committed