### PR TITLE
fix(ci): prevent missing Docker latest tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       custom_tag:
-        description: 'Optional custom tag for manual builds (e.g., v1.0.2)'
+        description: 'Optional custom tag for manual builds (SemVer tags v1.0.2 or 1.0.2 also update latest)'
         required: false
 
 jobs:
@@ -46,6 +46,11 @@ jobs:
             TAG=$BRANCH_NAME_SAFE
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
+          if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "PUBLISH_LATEST=true" >> $GITHUB_ENV
+          else
+            echo "PUBLISH_LATEST=false" >> $GITHUB_ENV
+          fi
 
       - name: Build and Push Docker image (multiarch)
         uses: docker/build-push-action@v7
@@ -55,4 +60,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             rja96/fireflyiii-telegram-bot:${{ env.TAG }}
-            ${{ startsWith(env.TAG, 'v') && 'rja96/fireflyiii-telegram-bot:latest' || '' }}
+            ${{ env.PUBLISH_LATEST == 'true' && 'rja96/fireflyiii-telegram-bot:latest' || '' }}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -25,6 +25,14 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must use v-prefixed SemVer, for example v1.3.0"
+            exit 1
+          fi
+
       - name: Create Git Tag
         run: |
           git tag ${{ github.event.inputs.version }}


### PR DESCRIPTION
Closes #27

## PR Type
- [x] Maintenance/tooling

## Summary
- Validates manual release versions as v-prefixed SemVer before creating tags.
- Updates Docker publish logic so SemVer tags with or without `v` publish `latest`.
- Prevents the `1.3.0` vs `v1.3.0` mismatch from skipping Docker Hub `latest` again.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release-version.yml` | Adds version validation requiring `v1.2.3` format before tag/release creation. |
| `.github/workflows/docker-publish.yml` | Computes `PUBLISH_LATEST` from SemVer tag format and uses it for `latest` tagging. |

## Test Plan
- [x] `git diff --check`
- [x] Workflow YAML parsed successfully with Ruby `YAML.load_file`
- [x] Published recovery tag `v1.3.0` and verified Docker workflow success
- [x] Verified Docker Hub `latest` and `v1.3.0` point to the same digest

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No secrets committed
- [x] Workflow-only change validated manually