### PR TITLE
fix(money): use decimal amounts and Firefly headers

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -1,20 +1,27 @@
 import logging
-import requests
 from typing import Optional
+
+import requests
 
 from bot.config import FIREFLY_URL, FIREFLY_TOKEN
 from bot.cache import cache
 
-HEADERS = {"Authorization": f"Bearer {FIREFLY_TOKEN}"}
 HTTP_TIMEOUT = 10  # seconds
 
 
-def _build_headers() -> dict:
-    """Build headers with validation."""
+def _build_headers(include_content_type: bool = False) -> dict:
+    """Build headers with validation and API negotiation."""
     if not FIREFLY_TOKEN:
         logging.error("FIREFLY_III_API_TOKEN is not set!")
         return {}
-    return {"Authorization": f"Bearer {FIREFLY_TOKEN}"}
+
+    headers = {
+        "Authorization": f"Bearer {FIREFLY_TOKEN}",
+        "Accept": "application/vnd.api+json",
+    }
+    if include_content_type:
+        headers["Content-Type"] = "application/json"
+    return headers
 
 
 def safe_get(endpoint: str, params: Optional[dict] = None) -> list:
@@ -22,7 +29,7 @@ def safe_get(endpoint: str, params: Optional[dict] = None) -> list:
     try:
         response = requests.get(
             f"{FIREFLY_URL}{endpoint}",
-            headers=HEADERS,
+            headers=_build_headers(),
             params=params,
             timeout=HTTP_TIMEOUT,
         )
@@ -41,7 +48,7 @@ def safe_post(endpoint: str, json_payload: dict) -> requests.Response:
     return requests.post(
         f"{FIREFLY_URL}{endpoint}",
         json=json_payload,
-        headers=HEADERS,
+        headers=_build_headers(include_content_type=True),
         timeout=HTTP_TIMEOUT,
     )
 

--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -1,10 +1,20 @@
 """Shared helpers for account display and common utilities."""
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 from bot.client import get_accounts, safe_get
+
+
+def _format_decimal_amount(value: str) -> str:
+    """Format Firefly amount string as fixed 2-decimal text."""
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return "0.00"
+    return format(amount, ".2f")
 
 
 async def format_account_display(
@@ -35,7 +45,7 @@ async def format_account_display(
 
     lines = [
         f"📊 *{account_name}*",
-        f"💰 Balance: {float(balance):.2f}",
+        f"💰 Balance: {_format_decimal_amount(balance)}",
         f"📋 Últimos {limit} movimientos:",
         "---",
     ]
@@ -44,8 +54,8 @@ async def format_account_display(
         for s in t["attributes"].get("transactions", []):
             fecha = s.get("date", "").split("T")[0]
             desc = s.get("description", "-")
-            monto = float(s.get("amount", "0.00"))
-            lines.append(f"{fecha} | {desc} | {monto:.2f}")
+            monto = _format_decimal_amount(s.get("amount", "0.00"))
+            lines.append(f"{fecha} | {desc} | {monto}")
 
     return "\n".join(lines)
 

--- a/bot/handlers/expense.py
+++ b/bot/handlers/expense.py
@@ -666,7 +666,7 @@ async def _create_expense_transaction(message_source, context: ContextTypes.DEFA
     today = datetime.now(pytz.timezone(TIMEZONE)).isoformat()
     transaction = {
         "type": "withdrawal",
-        "amount": str(ud["amount"]),
+        "amount": format(ud["amount"], ".2f"),
         "description": ud["description"],
         "source_id": source_id,
         "date": today,
@@ -806,7 +806,7 @@ async def quick_expense(update: Update, context: ContextTypes.DEFAULT_TYPE):
     today = datetime.now(pytz.timezone(TIMEZONE)).isoformat()
     transaction = {
         "type": "withdrawal",
-        "amount": str(amount),
+        "amount": format(amount, ".2f"),
         "description": description,
         "source_id": source_account["id"],
         "date": today,

--- a/bot/handlers/transfer.py
+++ b/bot/handlers/transfer.py
@@ -195,7 +195,7 @@ async def confirm_transfer(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "transactions": [
             {
                 "type": "transfer",
-                "amount": str(user_data["amount"]),
+                "amount": format(user_data["amount"], ".2f"),
                 "description": (
                     f"transferencia {user_data['source_name']}-{user_data['destination_name']}"
                 ),

--- a/bot/middleware.py
+++ b/bot/middleware.py
@@ -1,4 +1,5 @@
 """Authorization middleware and input validation helpers."""
+from decimal import Decimal, InvalidOperation
 import logging
 from typing import Optional
 
@@ -56,9 +57,21 @@ def sanitize_text(text: str, max_length: int = 255) -> str:
     return cleaned
 
 
-def validate_amount(text: str) -> Optional[float]:
-    """Parse amount from text. Returns float or None if invalid."""
+def validate_amount(text: str) -> Optional[Decimal]:
+    """Parse amount from text with exact 2-decimal scale enforcement."""
     try:
-        return float(text.replace(",", "."))
-    except (ValueError, AttributeError):
+        amount = Decimal(text.replace(",", "."))
+    except (InvalidOperation, AttributeError):
+        return None
+
+    if not amount.is_finite():
+        return None
+
+    exponent = amount.as_tuple().exponent
+    if exponent < -2:
+        return None
+
+    try:
+        return amount.quantize(Decimal("0.00"))
+    except InvalidOperation:
         return None

--- a/bot/middleware.py
+++ b/bot/middleware.py
@@ -67,11 +67,12 @@ def validate_amount(text: str) -> Optional[Decimal]:
     if not amount.is_finite():
         return None
 
-    exponent = amount.as_tuple().exponent
-    if exponent < -2:
-        return None
-
     try:
-        return amount.quantize(Decimal("0.00"))
+        quantized = amount.quantize(Decimal("0.00"))
     except InvalidOperation:
         return None
+
+    if amount != quantized:
+        return None
+
+    return quantized

--- a/tests/test_client_cache_middleware.py
+++ b/tests/test_client_cache_middleware.py
@@ -202,6 +202,8 @@ def test_validation_helpers():
     assert middleware.validate_amount("12,55") == Decimal("12.55")
     assert middleware.validate_amount("12.10") == Decimal("12.10")
     assert middleware.validate_amount("12.1") == Decimal("12.10")
+    assert middleware.validate_amount("10.000") == Decimal("10.00")
+    assert middleware.validate_amount("12.1200") == Decimal("12.12")
     assert middleware.validate_amount("12.123") is None
     assert middleware.validate_amount("nope") is None
     assert middleware.validate_amount("NaN") is None

--- a/tests/test_client_cache_middleware.py
+++ b/tests/test_client_cache_middleware.py
@@ -1,4 +1,5 @@
 import time
+from decimal import Decimal
 
 import pytest
 import requests
@@ -46,6 +47,38 @@ def test_safe_get_success_timeout_and_error(monkeypatch):
 
     monkeypatch.setattr(client.requests, "get", boom)
     assert client.safe_get("/boom") == []
+
+
+def test_safe_get_and_safe_post_build_api_headers(monkeypatch):
+    captured_get = {}
+    captured_post = {}
+
+    def fake_get(url, **kwargs):
+        captured_get["url"] = url
+        captured_get["headers"] = kwargs.get("headers", {})
+        return FakeResponse({"data": []})
+
+    def fake_post(url, **kwargs):
+        captured_post["url"] = url
+        captured_post["headers"] = kwargs.get("headers", {})
+        return FakeResponse({"data": {}})
+
+    monkeypatch.setattr(client, "FIREFLY_TOKEN", "test-token")
+    monkeypatch.setattr(client.requests, "get", fake_get)
+    monkeypatch.setattr(client.requests, "post", fake_post)
+
+    client.safe_get("/api/v1/accounts")
+    client.safe_post("/api/v1/transactions", {"transactions": []})
+
+    assert captured_get["headers"] == {
+        "Authorization": "Bearer test-token",
+        "Accept": "application/vnd.api+json",
+    }
+    assert captured_post["headers"] == {
+        "Authorization": "Bearer test-token",
+        "Accept": "application/vnd.api+json",
+        "Content-Type": "application/json",
+    }
 
 
 def test_get_accounts_uses_cache_and_local_filter_fallback(monkeypatch, all_accounts):
@@ -166,8 +199,12 @@ async def test_auth_open_allowed_and_denied(monkeypatch):
 
 def test_validation_helpers():
     assert middleware.sanitize_text("  abc  ", 2) == "ab"
-    assert middleware.validate_amount("12,55") == 12.55
+    assert middleware.validate_amount("12,55") == Decimal("12.55")
+    assert middleware.validate_amount("12.10") == Decimal("12.10")
+    assert middleware.validate_amount("12.1") == Decimal("12.10")
+    assert middleware.validate_amount("12.123") is None
     assert middleware.validate_amount("nope") is None
+    assert middleware.validate_amount("NaN") is None
 
 
 def test_keyboard_and_summary_helpers(expense_accounts, mixed_bills):
@@ -193,7 +230,7 @@ def test_keyboard_and_summary_helpers(expense_accounts, mixed_bills):
 
     summary = expense._build_confirmation_summary(
         {
-            "amount": 12.55,
+            "amount": Decimal("12.55"),
             "description": "supermercado pingo doce",
             "origin": "tarjeta",
             "destination": None,

--- a/tests/test_expense_flow.py
+++ b/tests/test_expense_flow.py
@@ -1,4 +1,5 @@
 import pytest
+from decimal import Decimal
 from telegram.ext import ConversationHandler
 
 from bot.constants import (
@@ -71,7 +72,7 @@ async def test_menu_to_expense_full_flow_preserves_multi_word_description(
         FakeUpdate(message=amount_message), context
     )
     assert state == SELECT_DESTINATION
-    assert context.user_data["amount"] == 12.55
+    assert context.user_data["amount"] == Decimal("12.55")
     assert context.user_data["description"] == "supermercado pingo doce"
 
     dest_query = FakeCallbackQuery("dest::pingo doce")
@@ -160,7 +161,9 @@ async def test_expense_button_flow_allows_optional_skips(
 async def test_select_budget_routes_to_bill_selection_and_skip(monkeypatch, all_accounts, expense_accounts, categories, budgets, bills):
     patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets, bills)
 
-    context = FakeContext(user_data={"amount": 10.0, "description": "cafe", "origin": "tarjeta"})
+    context = FakeContext(
+        user_data={"amount": Decimal("10.00"), "description": "cafe", "origin": "tarjeta"}
+    )
 
     budget_query = FakeCallbackQuery("budget::none")
     state = await expense.select_budget(FakeUpdate(callback_query=budget_query), context)
@@ -193,7 +196,9 @@ async def test_select_bill_preserves_correct_id_after_alphabetical_sort(
         unordered_bills,
     )
 
-    context = FakeContext(user_data={"amount": 10.0, "description": "cafe", "origin": "tarjeta"})
+    context = FakeContext(
+        user_data={"amount": Decimal("10.00"), "description": "cafe", "origin": "tarjeta"}
+    )
 
     budget_query = FakeCallbackQuery("budget::comida")
     state = await expense.select_budget(FakeUpdate(callback_query=budget_query), context)
@@ -213,7 +218,9 @@ async def test_select_bill_preserves_correct_id_after_alphabetical_sort(
 async def test_bill_selection_falls_back_to_tags_when_no_usable_active_bills(monkeypatch, all_accounts, expense_accounts, categories, budgets, mixed_bills):
     patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets, mixed_bills[2:])
 
-    context = FakeContext(user_data={"amount": 10.0, "description": "cafe", "origin": "tarjeta"})
+    context = FakeContext(
+        user_data={"amount": Decimal("10.00"), "description": "cafe", "origin": "tarjeta"}
+    )
 
     budget_query = FakeCallbackQuery("budget::comida")
     state = await expense.select_budget(FakeUpdate(callback_query=budget_query), context)
@@ -226,7 +233,9 @@ async def test_bill_selection_falls_back_to_tags_when_no_usable_active_bills(mon
 async def test_bill_selection_falls_back_to_tags_when_api_fails(monkeypatch, all_accounts, expense_accounts, categories, budgets):
     patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets, [])
 
-    context = FakeContext(user_data={"amount": 10.0, "description": "cafe", "origin": "tarjeta"})
+    context = FakeContext(
+        user_data={"amount": Decimal("10.00"), "description": "cafe", "origin": "tarjeta"}
+    )
 
     budget_query = FakeCallbackQuery("budget::comida")
     state = await expense.select_budget(FakeUpdate(callback_query=budget_query), context)
@@ -256,7 +265,7 @@ async def test_expense_button_flow_can_create_new_destination(
     )
 
     context = FakeContext({"user_data": {}})
-    context.user_data["amount"] = 20.0
+    context.user_data["amount"] = Decimal("20.00")
     context.user_data["description"] = "compra"
     context.user_data["origin"] = "tarjeta"
 
@@ -342,7 +351,7 @@ async def test_quick_expense_creates_minimal_transaction(monkeypatch, all_accoun
     await expense.quick_expense(FakeUpdate(message=message), context)
 
     transaction = created_payloads[0]["transactions"][0]
-    assert transaction["amount"] == "12.0"
+    assert transaction["amount"] == "12.00"
     assert transaction["description"] == "cafe"
     assert transaction["source_id"] == "asset-1"
     assert "bill_id" not in transaction

--- a/tests/test_transfer_flow.py
+++ b/tests/test_transfer_flow.py
@@ -1,4 +1,5 @@
 import pytest
+from decimal import Decimal
 from telegram.ext import ConversationHandler
 
 from bot.constants import (
@@ -61,7 +62,7 @@ async def test_menu_transfer_flow_happy_path_and_exact_payload(monkeypatch):
     amount_message = FakeMessage("25.50")
     state = await transfer.enter_amount(FakeUpdate(message=amount_message), context)
     assert state == TRANSFER_SELECT_SOURCE
-    assert context.user_data["amount"] == 25.5
+    assert context.user_data["amount"] == Decimal("25.50")
     assert button_texts(amount_message.replies[-1]) == ["tarjeta", "caja ahorro", "❌ Cancelar"]
 
     source_query = FakeCallbackQuery("transfer_source::asset-1")
@@ -89,7 +90,7 @@ async def test_menu_transfer_flow_happy_path_and_exact_payload(monkeypatch):
     transaction = created_payloads[0]["transactions"][0]
     assert transaction == {
         "type": "transfer",
-        "amount": "25.5",
+        "amount": "25.50",
         "description": "transferencia tarjeta-caja ahorro",
         "source_id": "asset-1",
         "destination_id": "asset-2",
@@ -127,7 +128,7 @@ async def test_transfer_keyboards_use_two_columns_and_filter_hidden_accounts(mon
     assert all(button.text != "efectivo" for row in keyboard for button in row)
 
     monkeypatch.setattr(transfer, "get_accounts", lambda account_type=None: accounts)
-    context = FakeContext(user_data={"amount": 10.0})
+    context = FakeContext(user_data={"amount": Decimal("10.00")})
     query = FakeCallbackQuery("transfer_source::asset-1")
 
     state = await transfer.select_source(FakeUpdate(callback_query=query), context)
@@ -147,7 +148,7 @@ async def test_transfer_rejects_same_source_and_destination(monkeypatch):
 
     context = FakeContext(
         user_data={
-            "amount": 10.0,
+            "amount": Decimal("10.00"),
             "source_id": "asset-1",
             "source_name": "tarjeta",
         }
@@ -166,7 +167,7 @@ async def test_transfer_stops_when_source_lookup_is_invalid(monkeypatch):
     monkeypatch.setattr(transfer, "get_accounts", lambda account_type=None: accounts)
     monkeypatch.setattr(transfer, "OCULTAR_CUENTAS_LOWER", [])
 
-    context = FakeContext(user_data={"amount": 10.0})
+    context = FakeContext(user_data={"amount": Decimal("10.00")})
     query = FakeCallbackQuery("transfer_source::missing")
 
     state = await transfer.select_source(FakeUpdate(callback_query=query), context)
@@ -181,7 +182,7 @@ async def test_transfer_stops_when_no_destination_accounts_remain(monkeypatch):
     monkeypatch.setattr(transfer, "get_accounts", lambda account_type=None: accounts)
     monkeypatch.setattr(transfer, "OCULTAR_CUENTAS_LOWER", ["caja ahorro", "efectivo"])
 
-    context = FakeContext(user_data={"amount": 10.0})
+    context = FakeContext(user_data={"amount": Decimal("10.00")})
     query = FakeCallbackQuery("transfer_source::asset-1")
 
     state = await transfer.select_source(FakeUpdate(callback_query=query), context)
@@ -200,7 +201,7 @@ async def test_transfer_cancellation_does_not_create_transaction(monkeypatch):
         return FakeResponse()
 
     monkeypatch.setattr(transfer, "create_transaction", fake_create_transaction)
-    context = FakeContext(user_data={"amount": 10.0})
+    context = FakeContext(user_data={"amount": Decimal("10.00")})
 
     state = await transfer.cancel_transfer(
         FakeUpdate(callback_query=FakeCallbackQuery("cancel_transfer")), context


### PR DESCRIPTION
Closes #29\n\n## PR Type\n- [x] Bug fix\n- [ ] New feature\n- [ ] Documentation only\n- [ ] Code refactoring\n- [ ] Maintenance/tooling\n- [ ] Breaking change\n\n## Summary\n- Replace float-based money parsing with Decimal validation that rejects over-precision instead of rounding.\n- Serialize Firefly transaction amounts as fixed-scale strings.\n- Add Firefly API Accept and POST Content-Type headers built at request time.\n\n## Changes\n| File | Change |\n|------|--------|\n| `bot/middleware.py` | Parse amounts as Decimal, reject non-finite values and more than 2 decimals. |\n| `bot/handlers/expense.py` | Serialize withdrawal amounts with fixed 2-decimal scale. |\n| `bot/handlers/transfer.py` | Serialize transfer amounts with fixed 2-decimal scale. |\n| `bot/handlers/common.py` | Format displayed Firefly amounts with Decimal instead of float. |\n| `bot/client.py` | Add Firefly JSON negotiation headers and build headers per request. |\n| `tests/*` | Cover Decimal amount behavior, fixed-scale payloads, and client headers. |\n\n## Test Plan\n- [x] `pytest` — 57 passed\n- [x] Fresh-context diff review completed\n- [x] Checked no dev token/secrets were written to files\n\n## Contributor Checklist\n- [x] Linked an approved issue\n- [x] Added exactly one `type:*` label\n- [x] No shell scripts changed\n- [x] Tests updated with behavior changes\n- [x] Conventional commit format\n- [x] No `Co-Authored-By` trailers\n