### PR TITLE
chore(ci): update actions for Node 24

### DIFF
--- a/.github/workflows/ci-compile.yml
+++ b/.github/workflows/ci-compile.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure Git
         run: |
@@ -39,7 +39,7 @@ jobs:
           git push origin ${{ github.event.inputs.version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.version }}
           name: Release ${{ github.event.inputs.version }}


### PR DESCRIPTION
Closes #33

## Summary
- Update GitHub-owned CI actions to Node.js 24-compatible majors.
- Update Docker login/buildx actions used by image publishing to Node.js 24-compatible majors.
- Update the release action to avoid Node.js 20 runtime warnings.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/ci-compile.yml` | Bumped `actions/checkout` to v5 and `actions/setup-python` to v6. |
| `.github/workflows/docker-publish.yml` | Bumped `actions/checkout` to v5, `docker/setup-buildx-action` to v4, and `docker/login-action` to v4. |
| `.github/workflows/release-version.yml` | Bumped `actions/checkout` to v5 and `softprops/action-gh-release` to v3. |

## Test Plan
- [x] Verified action metadata for updated actions uses Node.js 24.
- [x] Verified unchanged workflow actions are already Node.js 24-compatible.
- [x] Ran `git diff --check`.
- [x] Fresh-context review completed.

## Notes
- GitHub-hosted runners should already satisfy the required runner version. Self-hosted runners need Actions Runner v2.327.1+ for Node.js 24 actions.