### PR TITLE
feat(menu): add persistent quick keyboard

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,7 +1,11 @@
+import re
+
 from telegram.ext import ConversationHandler
 
 MENU_BUTTON_TEXT = "📋 Menú"
 EXPENSE_BUTTON_TEXT = "💸 Registrar gasto"
+MENU_BUTTON_PATTERN = f"^{re.escape(MENU_BUTTON_TEXT)}$"
+EXPENSE_BUTTON_PATTERN = f"^{re.escape(EXPENSE_BUTTON_TEXT)}$"
 
 # Conversation states for expense flow
 SELECT_ORIGIN, ENTER_AMOUNT_DESC, SELECT_DESTINATION, ENTER_NEW_DEST_NAME = range(4)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,5 +1,8 @@
 from telegram.ext import ConversationHandler
 
+MENU_BUTTON_TEXT = "📋 Menú"
+EXPENSE_BUTTON_TEXT = "💸 Registrar gasto"
+
 # Conversation states for expense flow
 SELECT_ORIGIN, ENTER_AMOUNT_DESC, SELECT_DESTINATION, ENTER_NEW_DEST_NAME = range(4)
 SELECT_CATEGORY, SELECT_BUDGET, SELECT_BILL, ENTER_TAGS, CONFIRM_EXPENSE = range(4, 9)

--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -3,7 +3,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, ConversationHandler
 
 from bot.client import get_accounts, safe_get
 
@@ -77,3 +77,16 @@ async def list_commands(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(text, parse_mode="Markdown")
     elif update.callback_query:
         await update.callback_query.message.reply_text(text, parse_mode="Markdown")
+
+
+async def cancel_current_flow_for_expense_shortcut(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+):
+    """End the current conversation before the expense shortcut starts a new flow."""
+    context.user_data.clear()
+    message = update.message or update.callback_query.message
+    await message.reply_text(
+        "Cancelé el flujo actual. Tocá 💸 Registrar gasto otra vez para empezar."
+    )
+    return ConversationHandler.END

--- a/bot/handlers/expense.py
+++ b/bot/handlers/expense.py
@@ -25,6 +25,7 @@ from bot.client import (
 )
 from bot.config import OCULTAR_CUENTAS_LOWER, TIMEZONE
 from bot.constants import (
+    EXPENSE_BUTTON_TEXT,
     SELECT_ORIGIN,
     ENTER_AMOUNT_DESC,
     SELECT_DESTINATION,
@@ -872,6 +873,7 @@ async def refresh_cache_command(update: Update, context: ContextTypes.DEFAULT_TY
 expense_conv = ConversationHandler(
     entry_points=[
         CommandHandler("expenseButton", start_expense_button),
+        MessageHandler(filters.Regex(f"^{EXPENSE_BUTTON_TEXT}$"), start_expense_button),
         CallbackQueryHandler(start_expense_button, pattern="^menu_expense$"),
     ],
     states={

--- a/bot/handlers/expense.py
+++ b/bot/handlers/expense.py
@@ -25,7 +25,9 @@ from bot.client import (
 )
 from bot.config import OCULTAR_CUENTAS_LOWER, TIMEZONE
 from bot.constants import (
+    EXPENSE_BUTTON_PATTERN,
     EXPENSE_BUTTON_TEXT,
+    MENU_BUTTON_PATTERN,
     SELECT_ORIGIN,
     ENTER_AMOUNT_DESC,
     SELECT_DESTINATION,
@@ -38,6 +40,7 @@ from bot.constants import (
 )
 from bot.middleware import require_auth, validate_amount, sanitize_text
 from bot.handlers.common import list_commands
+from bot.handlers.menu import cancel_to_menu
 
 logger = logging.getLogger(__name__)
 
@@ -878,36 +881,59 @@ expense_conv = ConversationHandler(
     ],
     states={
         SELECT_ORIGIN: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(select_origin, pattern="^origin::"),
         ],
         ENTER_AMOUNT_DESC: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_amount_description),
         ],
         SELECT_DESTINATION: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(select_destination, pattern="^dest::"),
         ],
         ENTER_NEW_DEST_NAME: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_new_dest_name),
         ],
         SELECT_CATEGORY: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(select_category, pattern="^cat::"),
         ],
         SELECT_BUDGET: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(select_budget, pattern="^budget::"),
         ],
         SELECT_BILL: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(select_bill, pattern="^bill::"),
         ],
         ENTER_TAGS: [
             CallbackQueryHandler(skip_tags, pattern="^tags::none$"),
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_tags),
         ],
         CONFIRM_EXPENSE: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
             CallbackQueryHandler(confirm_expense, pattern="^confirm_expense$"),
         ],
     },
     fallbacks=[
         CommandHandler("cancel", cancel),
+        CommandHandler("start", cancel_to_menu),
+        CommandHandler("menu", cancel_to_menu),
+        CommandHandler("expenseButton", start_expense_button),
+        MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+        MessageHandler(filters.Regex(EXPENSE_BUTTON_PATTERN), start_expense_button),
         CallbackQueryHandler(cancel, pattern="^cancelar$"),
     ],
     per_chat=True,

--- a/bot/handlers/income.py
+++ b/bot/handlers/income.py
@@ -17,10 +17,14 @@ from telegram.ext import (
 from bot.client import create_transaction, get_accounts
 from bot.config import OCULTAR_CUENTAS_LOWER, TIMEZONE
 from bot.constants import (
+    EXPENSE_BUTTON_PATTERN,
     INCOME_CONFIRM,
     INCOME_ENTER_AMOUNT_DESC,
     INCOME_SELECT_DESTINATION,
+    MENU_BUTTON_PATTERN,
 )
+from bot.handlers.common import cancel_current_flow_for_expense_shortcut
+from bot.handlers.menu import cancel_to_menu
 from bot.middleware import require_auth, sanitize_text, validate_amount
 
 logger = logging.getLogger(__name__)
@@ -210,17 +214,43 @@ income_conv = ConversationHandler(
     entry_points=[CallbackQueryHandler(start_income_button, pattern="^menu_income$")],
     states={
         INCOME_SELECT_DESTINATION: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             CallbackQueryHandler(select_income_destination, pattern="^income_dest::"),
         ],
         INCOME_ENTER_AMOUNT_DESC: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_income_amount_description),
         ],
         INCOME_CONFIRM: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             CallbackQueryHandler(confirm_income, pattern="^confirm_income$"),
         ],
     },
     fallbacks=[
         CommandHandler("cancel", cancel_income),
+        CommandHandler("start", cancel_to_menu),
+        CommandHandler("menu", cancel_to_menu),
+        CommandHandler(
+            "expenseButton",
+            cancel_current_flow_for_expense_shortcut,
+        ),
+        MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+        MessageHandler(
+            filters.Regex(EXPENSE_BUTTON_PATTERN),
+            cancel_current_flow_for_expense_shortcut,
+        ),
         CallbackQueryHandler(cancel_income, pattern="^cancelar_ingreso$"),
     ],
     per_chat=True,

--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -7,6 +7,7 @@ from telegram import (
 from telegram.ext import (
     CallbackQueryHandler,
     CommandHandler,
+    ConversationHandler,
     ContextTypes,
     MessageHandler,
     filters,
@@ -15,7 +16,11 @@ from telegram.ext import (
 from bot.handlers.common import list_commands
 from bot.handlers.assets import show_assets
 from bot.handlers import subscriptions
-from bot.constants import EXPENSE_BUTTON_TEXT, MENU_BUTTON_TEXT
+from bot.constants import (
+    EXPENSE_BUTTON_TEXT,
+    MENU_BUTTON_PATTERN,
+    MENU_BUTTON_TEXT,
+)
 from bot.middleware import require_auth
 
 
@@ -51,6 +56,13 @@ async def start_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 
+async def cancel_to_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """End an active conversation and show the main menu."""
+    context.user_data.clear()
+    await start_menu(update, context)
+    return ConversationHandler.END
+
+
 async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not await require_auth(update, context):
         return
@@ -75,7 +87,7 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
 menu_handlers = [
     CommandHandler("start", start_menu),
     CommandHandler("menu", start_menu),
-    MessageHandler(filters.Regex(f"^{MENU_BUTTON_TEXT}$"), start_menu),
+    MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), start_menu),
     # `menu_expense`, `menu_income`, and `menu_transfer` are intentionally handled by
     # ConversationHandlers so the dedicated flows own their state transitions.
     CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands|menu_subscriptions)$")

--- a/bot/handlers/menu.py
+++ b/bot/handlers/menu.py
@@ -1,10 +1,31 @@
-from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
-from telegram.ext import CallbackQueryHandler, CommandHandler, ContextTypes
+from telegram import (
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    ReplyKeyboardMarkup,
+    Update,
+)
+from telegram.ext import (
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from bot.handlers.common import list_commands
 from bot.handlers.assets import show_assets
 from bot.handlers import subscriptions
+from bot.constants import EXPENSE_BUTTON_TEXT, MENU_BUTTON_TEXT
 from bot.middleware import require_auth
+
+
+def main_reply_keyboard():
+    """Return the persistent keyboard for the most common bot actions."""
+    return ReplyKeyboardMarkup(
+        [[MENU_BUTTON_TEXT, EXPENSE_BUTTON_TEXT]],
+        resize_keyboard=True,
+        is_persistent=True,
+    )
 
 
 async def start_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -12,7 +33,7 @@ async def start_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     keyboard = [
-        [InlineKeyboardButton("💸 Registrar gasto", callback_data="menu_expense")],
+        [InlineKeyboardButton(EXPENSE_BUTTON_TEXT, callback_data="menu_expense")],
         [InlineKeyboardButton("💰 Registrar ingreso", callback_data="menu_income")],
         [InlineKeyboardButton("🔁 Transferir", callback_data="menu_transfer")],
         [InlineKeyboardButton("💼 Ver cuentas", callback_data="menu_assets")],
@@ -20,7 +41,14 @@ async def start_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton("🧾 Suscripciones pendientes", callback_data="menu_subscriptions")],
         [InlineKeyboardButton("📋 Ver comandos", callback_data="menu_commands")]
     ]
-    await update.message.reply_text("¿Qué querés hacer?", reply_markup=InlineKeyboardMarkup(keyboard))
+    await update.message.reply_text(
+        "Accesos rápidos disponibles abajo 👇",
+        reply_markup=main_reply_keyboard(),
+    )
+    await update.message.reply_text(
+        "¿Qué querés hacer?",
+        reply_markup=InlineKeyboardMarkup(keyboard),
+    )
 
 
 async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -47,6 +75,7 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
 menu_handlers = [
     CommandHandler("start", start_menu),
     CommandHandler("menu", start_menu),
+    MessageHandler(filters.Regex(f"^{MENU_BUTTON_TEXT}$"), start_menu),
     # `menu_expense`, `menu_income`, and `menu_transfer` are intentionally handled by
     # ConversationHandlers so the dedicated flows own their state transitions.
     CallbackQueryHandler(handle_menu_selection, pattern="^(menu_assets|menu_cuenta|menu_commands|menu_subscriptions)$")

--- a/bot/handlers/transfer.py
+++ b/bot/handlers/transfer.py
@@ -15,11 +15,15 @@ from telegram.ext import (
 from bot.client import create_transaction, get_accounts
 from bot.config import OCULTAR_CUENTAS_LOWER, TIMEZONE
 from bot.constants import (
+    EXPENSE_BUTTON_PATTERN,
+    MENU_BUTTON_PATTERN,
     TRANSFER_CONFIRM,
     TRANSFER_ENTER_AMOUNT,
     TRANSFER_SELECT_DESTINATION,
     TRANSFER_SELECT_SOURCE,
 )
+from bot.handlers.common import cancel_current_flow_for_expense_shortcut
+from bot.handlers.menu import cancel_to_menu
 from bot.middleware import require_auth, validate_amount
 
 logger = logging.getLogger(__name__)
@@ -247,20 +251,51 @@ transfer_conv = ConversationHandler(
     ],
     states={
         TRANSFER_ENTER_AMOUNT: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             MessageHandler(filters.TEXT & ~filters.COMMAND, enter_amount),
         ],
         TRANSFER_SELECT_SOURCE: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             CallbackQueryHandler(select_source, pattern="^transfer_source::"),
         ],
         TRANSFER_SELECT_DESTINATION: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             CallbackQueryHandler(select_destination, pattern="^transfer_destination::"),
         ],
         TRANSFER_CONFIRM: [
+            MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+            MessageHandler(
+                filters.Regex(EXPENSE_BUTTON_PATTERN),
+                cancel_current_flow_for_expense_shortcut,
+            ),
             CallbackQueryHandler(confirm_transfer, pattern="^confirm_transfer$"),
         ],
     },
     fallbacks=[
         CommandHandler("cancel", cancel_transfer),
+        CommandHandler("start", cancel_to_menu),
+        CommandHandler("menu", cancel_to_menu),
+        CommandHandler(
+            "expenseButton",
+            cancel_current_flow_for_expense_shortcut,
+        ),
+        MessageHandler(filters.Regex(MENU_BUTTON_PATTERN), cancel_to_menu),
+        MessageHandler(
+            filters.Regex(EXPENSE_BUTTON_PATTERN),
+            cancel_current_flow_for_expense_shortcut,
+        ),
         CallbackQueryHandler(cancel_transfer, pattern="^cancel_transfer$"),
     ],
     per_chat=True,

--- a/bot/main.py
+++ b/bot/main.py
@@ -36,10 +36,10 @@ def _validate_startup():
 def _register_handlers(app):
     """Register conversation handlers first and the callback catch-all last."""
     for handler in (
-        menu_handlers
-        + expense_handlers
-        + income_handlers
+        income_handlers
         + transfer_handlers
+        + expense_handlers
+        + menu_handlers
         + account_handlers
         + assets_handlers
     ):

--- a/tests/test_expense_flow.py
+++ b/tests/test_expense_flow.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from telegram.ext import ConversationHandler
 
 from bot.constants import (
+    EXPENSE_BUTTON_TEXT,
     SELECT_ORIGIN,
     ENTER_AMOUNT_DESC,
     SELECT_DESTINATION,
@@ -62,7 +63,6 @@ async def test_menu_to_expense_full_flow_preserves_multi_word_description(
     )
     assert state == SELECT_ORIGIN
     assert "tarjeta" in button_texts(menu_query.message.replies[-1])
-
     origin_query = FakeCallbackQuery("origin::tarjeta")
     state = await expense.select_origin(FakeUpdate(callback_query=origin_query), context)
     assert state == ENTER_AMOUNT_DESC
@@ -118,6 +118,21 @@ async def test_menu_to_expense_full_flow_preserves_multi_word_description(
     assert transaction["bill_id"] == "bill-1"
     assert "date" in transaction
     assert "Gasto registrado correctamente" in confirm_query.message.replies[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_persistent_expense_button_starts_step_by_step_flow(
+    monkeypatch, all_accounts, expense_accounts, categories, budgets
+):
+    patch_expense_data(monkeypatch, all_accounts, expense_accounts, categories, budgets)
+    context = FakeContext(user_data={"stale": "value"})
+    message = FakeMessage(EXPENSE_BUTTON_TEXT)
+
+    state = await expense.start_expense_button(FakeUpdate(message=message), context)
+
+    assert state == SELECT_ORIGIN
+    assert context.user_data == {}
+    assert "tarjeta" in button_texts(message.replies[-1])
 
 
 @pytest.mark.asyncio

--- a/tests/test_menu_assets_account.py
+++ b/tests/test_menu_assets_account.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bot.constants import EXPENSE_BUTTON_TEXT, MENU_BUTTON_TEXT
 from bot.handlers import account, assets, common, menu, subscriptions
 from tests.conftest import FakeCallbackQuery, FakeContext, FakeMessage, FakeUpdate, button_texts
 
@@ -9,6 +10,14 @@ async def test_start_and_menu_show_main_keyboard():
     message = FakeMessage("/start")
 
     await menu.start_menu(FakeUpdate(message=message), FakeContext())
+
+    quick_reply = message.replies[0]
+    quick_buttons = [
+        getattr(button, "text", button)
+        for row in quick_reply["reply_markup"].keyboard
+        for button in row
+    ]
+    assert quick_buttons == [MENU_BUTTON_TEXT, EXPENSE_BUTTON_TEXT]
 
     buttons = button_texts(message.replies[-1])
     assert "💸 Registrar gasto" in buttons

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -3,7 +3,27 @@ from types import SimpleNamespace
 import pytest
 from telegram.ext import CallbackQueryHandler
 
+from bot.constants import (
+    CONFIRM_EXPENSE,
+    ENTER_AMOUNT_DESC,
+    ENTER_NEW_DEST_NAME,
+    ENTER_TAGS,
+    INCOME_CONFIRM,
+    INCOME_ENTER_AMOUNT_DESC,
+    INCOME_SELECT_DESTINATION,
+    SELECT_BILL,
+    SELECT_BUDGET,
+    SELECT_CATEGORY,
+    SELECT_DESTINATION,
+    SELECT_ORIGIN,
+    TRANSFER_CONFIRM,
+    TRANSFER_ENTER_AMOUNT,
+    TRANSFER_SELECT_DESTINATION,
+    TRANSFER_SELECT_SOURCE,
+)
 from bot import main
+from bot.handlers import expense, income, menu, transfer
+from bot.handlers.common import cancel_current_flow_for_expense_shortcut
 
 
 class FakeApp:
@@ -48,9 +68,82 @@ def test_register_handlers_adds_all_known_handlers_and_catch_all_last(monkeypatc
 
     main._register_handlers(app)
 
-    assert app.handlers[:-1] == list(sentinel_handlers.values())
+    assert app.handlers[:-1] == [
+        sentinel_handlers["income"],
+        sentinel_handlers["transfer"],
+        sentinel_handlers["expense"],
+        sentinel_handlers["menu"],
+        sentinel_handlers["account"],
+        sentinel_handlers["assets"],
+    ]
     assert isinstance(app.handlers[-1], CallbackQueryHandler)
     assert app.handlers[-1].callback is main.handle_callback
+
+
+def _callbacks(handlers):
+    return [handler.callback for handler in handlers]
+
+
+def test_quick_menu_button_is_handled_in_all_active_conversation_states():
+    expense_states = [
+        SELECT_ORIGIN,
+        ENTER_AMOUNT_DESC,
+        SELECT_DESTINATION,
+        ENTER_NEW_DEST_NAME,
+        SELECT_CATEGORY,
+        SELECT_BUDGET,
+        SELECT_BILL,
+        ENTER_TAGS,
+        CONFIRM_EXPENSE,
+    ]
+    for state in expense_states:
+        assert menu.cancel_to_menu in _callbacks(expense.expense_conv.states[state])
+
+    income_states = [INCOME_SELECT_DESTINATION, INCOME_ENTER_AMOUNT_DESC, INCOME_CONFIRM]
+    for state in income_states:
+        assert menu.cancel_to_menu in _callbacks(income.income_conv.states[state])
+
+    transfer_states = [
+        TRANSFER_ENTER_AMOUNT,
+        TRANSFER_SELECT_SOURCE,
+        TRANSFER_SELECT_DESTINATION,
+        TRANSFER_CONFIRM,
+    ]
+    for state in transfer_states:
+        assert menu.cancel_to_menu in _callbacks(transfer.transfer_conv.states[state])
+
+
+def test_quick_expense_button_is_handled_in_all_active_conversation_states():
+    expense_states = [
+        SELECT_ORIGIN,
+        ENTER_AMOUNT_DESC,
+        SELECT_DESTINATION,
+        ENTER_NEW_DEST_NAME,
+        SELECT_CATEGORY,
+        SELECT_BUDGET,
+        SELECT_BILL,
+        ENTER_TAGS,
+        CONFIRM_EXPENSE,
+    ]
+    for state in expense_states:
+        assert expense.start_expense_button in _callbacks(expense.expense_conv.states[state])
+
+    income_states = [INCOME_SELECT_DESTINATION, INCOME_ENTER_AMOUNT_DESC, INCOME_CONFIRM]
+    for state in income_states:
+        assert cancel_current_flow_for_expense_shortcut in _callbacks(
+            income.income_conv.states[state]
+        )
+
+    transfer_states = [
+        TRANSFER_ENTER_AMOUNT,
+        TRANSFER_SELECT_SOURCE,
+        TRANSFER_SELECT_DESTINATION,
+        TRANSFER_CONFIRM,
+    ]
+    for state in transfer_states:
+        assert cancel_current_flow_for_expense_shortcut in _callbacks(
+            transfer.transfer_conv.states[state]
+        )
 
 
 def test_main_builds_application_and_runs_polling(monkeypatch):


### PR DESCRIPTION
Closes #35

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a persistent Telegram reply keyboard with quick actions for Menu and Registrar gasto.
- Routes the persistent expense button into the existing step-by-step expense flow.
- Covers the quick keyboard and expense entry behavior with tests.

## Changes
| File | Change |
|------|--------|
| `bot/constants.py` | Adds shared quick-action button labels. |
| `bot/handlers/menu.py` | Sends the persistent quick keyboard and handles the menu quick action. |
| `bot/handlers/expense.py` | Starts the step-by-step expense flow from the persistent expense button. |
| `tests/test_menu_assets_account.py` | Verifies the persistent keyboard buttons are attached. |
| `tests/test_expense_flow.py` | Verifies the persistent expense button starts the step-by-step flow. |

## Test Plan
- [x] `pytest tests/test_menu_assets_account.py tests/test_expense_flow.py` — 25 passed, 1 existing PTB warning about `per_message=False`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant tests
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers